### PR TITLE
Redis for v1 api work

### DIFF
--- a/cluster/index.ts
+++ b/cluster/index.ts
@@ -51,8 +51,6 @@ export const kubeconfig = cluster.status.apply(status => {
   }
 });
 
-// export const kubeconfig = cluster.kubeConfigs[0]!.rawConfig;
-
 export const provider = new k8s.Provider("k8s-provider",
   { kubeconfig },
   { dependsOn: [cluster, nodePool] },

--- a/grafana/index.ts
+++ b/grafana/index.ts
@@ -76,7 +76,7 @@ export const chart = new k8s.helm.v3.Chart(
   {
     namespace: namespace.metadata.name,
     chart: "grafana",
-    fetchOpts: { repo: "https://grafana.github.io/helm-charts" },
+    fetchOpts: { repo: "https://grafana.github.io/helm-charts", version: "6.1.9" },
     values: {
       envFromSecret: creds.metadata.name,
       adminUser: "admin",

--- a/index.ts
+++ b/index.ts
@@ -14,3 +14,4 @@ import "./metabase";
 import "./grafana";
 import "./loki";
 import "./kata";
+import "./redis";

--- a/metabase/index.ts
+++ b/metabase/index.ts
@@ -90,6 +90,7 @@ export const chart = new k8s.helm.v3.Chart(
     namespace: namespace.metadata.name,
     chart: "metabase",
     repo: "stable",
+    fetchOpts: { repo: "https://repo.chartcenter.io" },
     values: {
       database: {
         type: "PostgreSQL",

--- a/prometheus/index.ts
+++ b/prometheus/index.ts
@@ -43,7 +43,7 @@ async function getFiles(dir: string) {
     {
       namespace: namespace.metadata.name,
       chart: "prometheus",
-      fetchOpts: { repo: "https://prometheus-community.github.io/helm-charts" },
+      fetchOpts: { repo: "https://prometheus-community.github.io/helm-charts", version: "12.0.1" },
       values: {
         alertmanager: {
           replicaCount: 2,

--- a/promscale/index.ts
+++ b/promscale/index.ts
@@ -60,7 +60,7 @@ export const chart = new k8s.helm.v3.Chart(
   {
     namespace: namespace.metadata.name,
     chart: "promscale",
-    fetchOpts: { repo: "https://charts.timescale.com" },
+    fetchOpts: { repo: "https://charts.timescale.com", "version": "0.1.2" },
     values: {
       image: "timescale/promscale:0.1.2",
       connection: {

--- a/promtail/index.ts
+++ b/promtail/index.ts
@@ -9,7 +9,7 @@ export const chart = new k8s.helm.v3.Chart(
     chart: "promtail",
     fetchOpts: {
       repo: "https://grafana.github.io/loki/charts",
-        version: "2.0.1",
+      version: "2.0.1",
     },
     values: {
       loki: {

--- a/promtail/index.ts
+++ b/promtail/index.ts
@@ -9,6 +9,7 @@ export const chart = new k8s.helm.v3.Chart(
     chart: "promtail",
     fetchOpts: {
       repo: "https://grafana.github.io/loki/charts",
+        version: "2.0.1",
     },
     values: {
       loki: {

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -1,0 +1,32 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as ocean from "@pulumi/digitalocean";
+import { project, vpc, cluster } from "../cluster";
+
+
+const conf = new pulumi.Config("digitalocean");
+
+export const redis = new ocean.DatabaseCluster("api-redis-cluster",
+    {
+        engine: "redis",
+        nodeCount: 2,
+        region: conf.require("region") as ocean.Region,
+        size: "db-s-1vcpu-2gb",
+        version: "6",
+        privateNetworkUuid: vpc.id,
+    },
+    {
+        parent: project,
+    }
+);
+
+export const redisfw = new ocean.DatabaseFirewall("api-redis-fw",
+    {
+        clusterId: redis.id,
+        rules: [
+            {
+                type: "k8s",
+                value: cluster.id,
+            }
+        ]
+    },
+)

--- a/timescale/index.ts
+++ b/timescale/index.ts
@@ -87,7 +87,7 @@ export const chart = new k8s.helm.v3.Chart(
   {
     namespace: namespace.metadata.name,
     chart: "timescaledb-single",
-    fetchOpts: { repo: "https://charts.timescale.com" },
+    fetchOpts: { repo: "https://charts.timescale.com", version: "0.7.1" },
     values: {
       image: { tag: "pg12.4-ts1.7.4-p1" },
       replicaCount: 2,


### PR DESCRIPTION
Adds a redis cluster to the platform for use by the v1 api work

Also:
- pin helm charts so that `pulumi up` doesn't have a massive diff everytime you run it
- minor fixes for pulumi