### PR TITLE
Switch to k8s router and micro namespace

### DIFF
--- a/micro/index.ts
+++ b/micro/index.ts
@@ -44,7 +44,7 @@ export const jwtCert = new crd.certmanager.v1.Certificate(
   {
     metadata: {
       name: "jwt-creds",
-      namespace: "server"
+      namespace: "micro"
     },
     spec: {
       duration: "87600h", // 10 years
@@ -91,7 +91,7 @@ export const runtimeServiceAccount = new k8s.core.v1.ServiceAccount(
   "micro-runtime-sa",
   {
     metadata: {
-      namespace: "server"
+      namespace: "micro"
     }
   },
   { provider }
@@ -161,7 +161,7 @@ export const runtimeClusterRoleBinding = new k8s.rbac.v1.ClusterRoleBinding(
       {
         kind: "ServiceAccount",
         name: runtimeServiceAccount.metadata.name,
-        namespace: "server"
+        namespace: "micro"
       }
     ],
     roleRef: {
@@ -178,7 +178,7 @@ export const runtimeRoleBinding = new k8s.rbac.v1.RoleBinding(
   {
     metadata: {
       name: "micro-runtime",
-      namespace: "server"
+      namespace: "micro"
     },
     roleRef: {
       apiGroup: "rbac.authorization.k8s.io",
@@ -201,7 +201,7 @@ export const spacesSecret = new k8s.core.v1.Secret(
   {
     metadata: {
       name: "do-spaces",
-      namespace: "server"
+      namespace: "micro"
     },
     stringData: {
       accessId: conf.require("spacesAccessId"),
@@ -346,7 +346,7 @@ function microDeployment(srv: string, port: number): k8s.apps.v1.Deployment {
     {
       metadata: {
         name: `micro-${srv}`,
-        namespace: "server",
+        namespace: "micro",
         labels: {
           name: srv,
           version: "latest",
@@ -466,7 +466,7 @@ export const networkService = new k8s.core.v1.Service(
   {
     metadata: {
       name: "micro-network",
-      namespace: "server",
+      namespace: "micro",
       labels: {
         name: "network",
         version: "latest",
@@ -515,7 +515,7 @@ export const apiDeployment = new k8s.apps.v1.Deployment(
   {
     metadata: {
       name: "micro-api",
-      namespace: "server",
+      namespace: "micro",
       labels: {
         name: "api",
         version: "latest",
@@ -610,7 +610,7 @@ export const apiService = new k8s.core.v1.Service(
   {
     metadata: {
       name: "micro-api",
-      namespace: "server",
+      namespace: "micro",
       labels: {
         name: "api",
         version: "latest",
@@ -640,7 +640,7 @@ export const proxyDeployment = new k8s.apps.v1.Deployment(
   {
     metadata: {
       name: "micro-proxy",
-      namespace: "server",
+      namespace: "micro",
       labels: {
         name: "proxy",
         version: "latest",
@@ -731,7 +731,7 @@ export const proxyService = new k8s.core.v1.Service(
   {
     metadata: {
       name: "micro-proxy",
-      namespace: "server",
+      namespace: "micro",
       labels: {
         name: "proxy",
         version: "latest",


### PR DESCRIPTION
Switching to k8s dns based routing is going to remove most of our networking bugs. This requires us to have micro in the "micro" namespace which likely makes the most sense anyway.